### PR TITLE
[BUGFIX] Fix error handling in deleteAction() function

### DIFF
--- a/Classes/Controller/LogController.php
+++ b/Classes/Controller/LogController.php
@@ -574,6 +574,8 @@ class LogController extends ActionController
             $log->setEmail($user['email']);
             $log->setPid($user['pid']);
             $checkSession = true;
+        } else {
+            $error = 1;
         }
         if ($error == 0) {
             $email = $log->getEmail();


### PR DESCRIPTION
Add error when the $log parameter is null and the $user['email'] is not set

Relates: https://github.com/bihor/fp_newsletter/issues/70