### PR TITLE
[BUGFIX] Use correct class for widget parameter

### DIFF
--- a/Classes/Widgets/RecentLogEntriesWidget.php
+++ b/Classes/Widgets/RecentLogEntriesWidget.php
@@ -22,7 +22,7 @@ class RecentLogEntriesWidget implements WidgetInterface, RequestAwareWidgetInter
     public function __construct(
         private readonly WidgetConfigurationInterface $configuration,
         private readonly BackendViewFactory $backendViewFactory,
-        private readonly ParticipantsDataProvider     $dataProvider,
+        private readonly LogDataProvider     $dataProvider,
         array            $options = []
     )
     {


### PR DESCRIPTION
Otherwise there is an exception in the Dashboard Module:

> Fixpunkt\FpNewsletter\Widgets\RecentLogEntriesWidget::__construct(): Argument #3 ($dataProvider) must be of type Fixpunkt\FpNewsletter\Widgets\ParticipantsDataProvider, Fixpunkt\FpNewsletter\Widgets\Provider\LogDataProvider given